### PR TITLE
Added table data for reporters to use

### DIFF
--- a/lib/src/feature_file_runner.dart
+++ b/lib/src/feature_file_runner.dart
@@ -136,7 +136,7 @@ class FeatureFileRunner {
     await _log(
         "Attempting to run step '${step.name}'", step.debug, MessageLevel.info);
     await _reporter
-        .onStepStarted(StartedMessage(Target.step, step.name, step.debug));
+        .onStepStarted(StepStartedMessage(Target.step, step.name, step.debug, step.table));
     if (skipExecution) {
       result = StepResult(0, StepExecutionResult.skipped);
     } else {

--- a/lib/src/reporters/aggregated_reporter.dart
+++ b/lib/src/reporters/aggregated_reporter.dart
@@ -43,7 +43,7 @@ class AggregatedReporter extends Reporter {
   }
 
   @override
-  Future<void> onStepStarted(StartedMessage message) async {
+  Future<void> onStepStarted(StepStartedMessage message) async {
     await _invokeReporters((r) async => await r.onStepStarted(message));
   }
 

--- a/lib/src/reporters/messages.dart
+++ b/lib/src/reporters/messages.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_gherkin/src/gherkin/models/table.dart';
 import 'package:flutter_gherkin/src/gherkin/runnables/debug_information.dart';
 import 'package:flutter_gherkin/src/gherkin/steps/step_run_result.dart';
 
@@ -17,6 +18,14 @@ class FinishedMessage {
   final RunnableDebugInformation context;
 
   FinishedMessage(this.target, this.name, this.context);
+}
+
+class StepStartedMessage extends StartedMessage {
+  final Table table;
+
+  StepStartedMessage(
+      Target target, String name, RunnableDebugInformation context, this.table)
+      : super(target, name, context);
 }
 
 class StepFinishedMessage extends FinishedMessage {

--- a/lib/src/reporters/reporter.dart
+++ b/lib/src/reporters/reporter.dart
@@ -8,7 +8,7 @@ abstract class Reporter {
   Future<void> onFeatureFinished(FinishedMessage message) async {}
   Future<void> onScenarioStarted(StartedMessage message) async {}
   Future<void> onScenarioFinished(ScenarioFinishedMessage message) async {}
-  Future<void> onStepStarted(StartedMessage message) async {}
+  Future<void> onStepStarted(StepStartedMessage message) async {}
   Future<void> onStepFinished(StepFinishedMessage message) async {}
   Future<void> onException(Exception exception, StackTrace stackTrace) async {}
   Future<void> message(String message, MessageLevel level) async {}

--- a/test/mocks/reporter_mock.dart
+++ b/test/mocks/reporter_mock.dart
@@ -35,7 +35,7 @@ class ReporterMock extends Reporter {
   Future<void> onScenarioFinished(FinishedMessage message) async =>
       onScenarioFinishedInvocationCount += 1;
   @override
-  Future<void> onStepStarted(StartedMessage message) async =>
+  Future<void> onStepStarted(StepStartedMessage message) async =>
       onStepStartedInvocationCount += 1;
   @override
   Future<void> onStepFinished(StepFinishedMessage message) async {


### PR DESCRIPTION
I created my own json reporter which requires the step's table data to be more complete. I can add the json reporter as a pull request later if you want. The json file can be used with this tool: https://www.npmjs.com/package/cucumber-html-reporter , to generate awesome looking html reports.