### PR TITLE
reverse arguments and expect on the presence step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+* **BREAKING CHANGE** reverse order of `driver` and `finder` in `FlutterDriverUtils#isPresent`. This makes this method's arguments more consistent with all other instance methods in the class by including `driver` first.
+* `expect` the presence of `ThenExpectWidgetToBePresent`. If the widget was not present, the method would simply timeout and not report an error for the step.
+
 ## [1.1.7+7] - 25/03/2019
 * Added the ability to test against an already running app; enabling you to debug a running application while it has tests executed against it.  Setting the configuration property `runningAppProtocolEndpointUri` to the service protocol endpoint (found in stdout when an app has `--verbose` logging turrned on) will ensure that the existing app is connected to rather than starting a new instance of the app.  NOTE: ensure the app you are trying to connect to calls `enableFlutterDriverExtension()` when it starts up otherwise the Flutter Driver will not be able to connect to it.
 

--- a/lib/src/flutter/steps/given_i_open_the_drawer_step.dart
+++ b/lib/src/flutter/steps/given_i_open_the_drawer_step.dart
@@ -16,7 +16,7 @@ class GivenOpenDrawer extends Given1WithWorld<String, FlutterWorld> {
   Future<void> executeStep(String action) async {
     final drawerFinder = find.byType("Drawer");
     final isOpen =
-        await FlutterDriverUtils.isPresent(drawerFinder, world.driver);
+        await FlutterDriverUtils.isPresent(world.driver, drawerFinder);
     // https://github.com/flutter/flutter/issues/9002#issuecomment-293660833
     if (isOpen && action == "close") {
       // Swipe to the left across the whole app to close the drawer

--- a/lib/src/flutter/steps/then_expect_widget_to_be_present_step.dart
+++ b/lib/src/flutter/steps/then_expect_widget_to_be_present_step.dart
@@ -20,10 +20,11 @@ class ThenExpectWidgetToBePresent
 
   @override
   Future<void> executeStep(String key, int seconds) async {
-    await FlutterDriverUtils.isPresent(
-      find.byValueKey(key),
+    final isPresent = await FlutterDriverUtils.isPresent(
       world.driver,
+      find.byValueKey(key),
       timeout: Duration(seconds: seconds),
     );
+    expect(isPresent, true);
   }
 }

--- a/lib/src/flutter/utils/driver_utils.dart
+++ b/lib/src/flutter/utils/driver_utils.dart
@@ -4,8 +4,8 @@ import 'package:flutter_driver/flutter_driver.dart';
 
 class FlutterDriverUtils {
   static Future<bool> isPresent(
-    SerializableFinder finder,
-    FlutterDriver driver, {
+    FlutterDriver driver,
+    SerializableFinder finder, {
     Duration timeout = const Duration(seconds: 1),
   }) async {
     try {


### PR DESCRIPTION
Hey @jonsamwell , I've been using this package for a few months. It's incredibly reliable and has great error messaging. I really appreciate your effort in maintaining this and the quality.

I have a handful of other step definitions that might be useful, but I know that more code means more maintenance. Specifically, these would be expect when a widget is absent, tapping within a parent widget, wait until a widget is absent, and discovering text within a parent widget. Should I open a PR for these?

Lastly, the code for this PR includes a breaking change. There's a lot of hubris here - who thinks they can submit their first PR with a breaking change? - but I think it's an important change to make sooner than later.

Below are my suggested release notes:

* **BREAKING CHANGE** reverse order of `driver` and `finder` in `FlutterDriverUtils#isPresent`. This makes this method's arguments more consistent with all other instance methods in the class by including `driver` first.
* `expect` the presence of `ThenExpectWidgetToBePresent`. If the widget was not present, the method would simply timeout and not report an error for the step.