### PR TITLE
add slack reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,6 +915,7 @@ A reporter is a class that is able to report on the progress of the test run. In
 * `TestRunSummaryReporter` - prints the results and duration of the test run once the run has completed - colours the output.
 * `JsonReporter` - creates a JSON file with the results of the test run which can then be used by 'https://www.npmjs.com/package/cucumber-html-reporter.' to create a HTML report.  You can pass in the file path of the json file to be created.
 * `FlutterDriverReporter` - prints the output from Flutter Driver. Flutter driver logs all messages to the stderr stream by default so most CI servers would mark the process as failed if anything is logged to the stderr stream (even if the Flutter driver logs are only info messages).  This reporter ensures the log messages are output to the most appropriate stream depending on their log level.
+* `SlackReporter` - notifies a Slack channel for every failed step and every successful feature. This requires a bot installed to your workspace with the files:write scope (to upload screenshots of failed steps) and the chat.write permission (to publish test results).
 
 You can create your own custom reporter by inheriting from the base `Reporter` class and overriding the one or many of the methods to direct the output message.  The `Reporter` defines the following methods that can be overridden.  All methods must return a `Future<void>` and can be async.
 

--- a/lib/src/flutter/reporters/slack_reporter.dart
+++ b/lib/src/flutter/reporters/slack_reporter.dart
@@ -115,6 +115,7 @@ class SlackReporter extends Reporter {
 
   SlackReporter(this.slackMessenger, {this.startLabel});
 
+  @override
   Future<void> onException(exception, stackTrace) {
     final payload = [
       slackMessenger.divider,
@@ -127,10 +128,12 @@ class SlackReporter extends Reporter {
     return slackMessenger.notifySlack(payload);
   }
 
+  @override
   Future<void> message(msg, level) async {
     if (level == MessageLevel.error) await slackMessenger.sendText(msg);
   }
 
+  @override
   Future<void> onFeatureFinished(feature) async {
     features.add(feature);
     final allScenariosPassed = scenariosInActiveFeature.every((s) => s.passed);
@@ -147,6 +150,7 @@ class SlackReporter extends Reporter {
     scenariosInActiveFeature.clear();
   }
 
+  @override
   Future<void> onScenarioFinished(scenario) async {
     scenarios.add(scenario);
     scenariosInActiveFeature.add(scenario);
@@ -168,6 +172,7 @@ class SlackReporter extends Reporter {
     }
   }
 
+  @override
   Future<void> onStepFinished(step) async {
     if (step.result.result != StepExecutionResult.pass &&
         firstFailedStepInActiveScenario == null) {
@@ -175,9 +180,11 @@ class SlackReporter extends Reporter {
     }
   }
 
+  @override
   Future<void> onTestRunStarted() async =>
       slackMessenger.start('Starting tests for $startLabel');
 
+  @override
   Future<void> onTestRunFinished() async {
     final successfulNames =
         scenarios.where((s) => s.passed).map((s) => '* ${s.name}');

--- a/lib/src/flutter/reporters/slack_reporter.dart
+++ b/lib/src/flutter/reporters/slack_reporter.dart
@@ -21,7 +21,7 @@ class SlackMessenger {
   /// Use the alphanumeric ending of the URL.
   final String slackChannelId;
 
-  /// The message to reply to. This will nest the test run, reducing channel noise.
+  /// The parent message ID. This will nest the test run to reduce channel noise.
   String threadTs;
 
   SlackMessenger({
@@ -63,7 +63,8 @@ class SlackMessenger {
     return notifySlack(payload);
   }
 
-  /// Initial message will set [threadTs] so that subsequent messages reply under one thread.
+  /// Initial message will set [threadTs] so that subsequent
+  /// messages reply under one thread when [threadMessages] is true.
   Future<http.Response> start(String startMessage,
       {bool threadMessages = true}) async {
     threadTs = null;
@@ -113,7 +114,8 @@ class SlackReporter extends Reporter {
 
   final SlackMessenger slackMessenger;
 
-  /// Reported on the parent thread of the test run. Defaults to `Starting tests`.
+  /// Reported as the initial message (or parent thread when [threadResults] is `true`)
+  /// of the test run. Defaults to `Starting tests`.
   final String startLabel;
 
   /// Whether the test run should be threaded under a single message. Defaults `true`.

--- a/lib/src/flutter/reporters/slack_reporter.dart
+++ b/lib/src/flutter/reporters/slack_reporter.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:gherkin/gherkin.dart';
+import 'package:meta/meta.dart';
+
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class SlackMessenger {
+  /// After [creating a Slack Bot](https://api.slack.com/apps) with
+  /// the proper scopes (chat.write, files:write), an Oauth token will be
+  /// generated after installing for your Slack team (https://api.slack.com/apps/xxx/install-on-team)
+  ///
+  /// If the images aren't uploading, test your token on Slack: https://api.slack.com/methods/files.upload/test
+  /// Often, the solution is to invite the bot to the proper Slack channel.
+  final String slackOauthToken;
+
+  /// Easiest way to find this: right click the channel name in Slack>"Open Link" .
+  /// Use the alphanumeric ending of the URL.
+  final String slackChannelId;
+
+  /// The message to reply to. This will nest the test run, reducing channel noise.
+  String threadTs;
+
+  SlackMessenger({
+    @required this.slackOauthToken,
+    @required this.slackChannelId,
+  });
+
+  /// Format a Slack text Block
+  Map<String, dynamic> buildTextSection(String txt) => {
+        'type': 'section',
+        'text': {'type': 'mrkdwn', 'text': txt}
+      };
+
+  /// Slack Block divider
+  Map<String, dynamic> get divider => {'type': 'divider'};
+
+  Future<void> message(msg, level) async {
+    if (level == MessageLevel.error) await sendText(msg);
+  }
+
+  Future<http.Response> notifySlack(List<Map<String, dynamic>> payload) => http
+      .post(
+        'https://slack.com/api/chat.postMessage',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $slackOauthToken',
+        },
+        body: jsonEncode({
+          'channel': slackChannelId,
+          'blocks': payload,
+          if (threadTs != null) 'thread_ts': threadTs,
+        }),
+      )
+      .catchError(print);
+
+  /// Send normal text. Slack-supported Markdown is available.
+  Future<http.Response> sendText(String msg) {
+    final payload = [buildTextSection(msg)];
+    return notifySlack(payload);
+  }
+
+  /// Initial message will set [threadTs] so that subsequent messages reply under one thread.
+  Future<http.Response> start(String startMessage) async {
+    threadTs = null;
+    final resp = await sendText(startMessage);
+    threadTs = jsonDecode(resp.body)['ts'];
+    return resp;
+  }
+
+  Future<void> uploadScreenshot(String path, String title) async {
+    try {
+      if (slackOauthToken != null) {
+        // pulled from https://api.slack.com/methods/files.upload/test
+        final endpoint = _slackEndpoint('files.upload', {
+          'channels': slackChannelId,
+          if (threadTs != null) 'thread_ts': threadTs,
+          'title': title,
+        });
+        final request = http.MultipartRequest('POST', Uri.parse(endpoint));
+        final file = await http.MultipartFile.fromPath('file', path);
+        request.files.add(file);
+        return request.send();
+      }
+    } catch (e, st) {
+      print('Failed to take screenshot\n$e\n$st');
+    }
+  }
+
+  String _slackEndpoint(String method, Map<String, String> queryParameters) {
+    final baseUrl = 'https://slack.com/api/$method?token=$slackOauthToken';
+    return queryParameters.entries.fold(baseUrl, (acc, entry) {
+      final encoded = Uri.encodeComponent(entry.value);
+      return '$acc&${entry.key}=$encoded';
+    });
+  }
+}
+
+class SlackReporter extends Reporter {
+  final SlackMessenger slackMessenger;
+
+  /// Reported on the parent thread of the test run.
+  final String startLabel;
+
+  final features = <FinishedMessage>[];
+  final scenarios = <ScenarioFinishedMessage>[];
+  final scenariosInActiveFeature = <ScenarioFinishedMessage>[];
+  StepFinishedMessage firstFailedStepInActiveScenario;
+
+  /// The number of scenario failures before the test suite will terminate
+  /// and cease reporting to Slack.
+  static const int MAXIMUM_TOLERATED_FAILURES = 15;
+
+  SlackReporter(this.slackMessenger, {this.startLabel});
+
+  Future<void> onException(exception, stackTrace) {
+    final payload = [
+      slackMessenger.divider,
+      slackMessenger.buildTextSection(':bangbang: Exception :bangbang:'),
+      slackMessenger.buildTextSection(exception.toString()),
+      slackMessenger.buildTextSection('```$stackTrace```'),
+      slackMessenger.divider,
+    ];
+
+    return slackMessenger.notifySlack(payload);
+  }
+
+  Future<void> message(msg, level) async {
+    if (level == MessageLevel.error) await slackMessenger.sendText(msg);
+  }
+
+  Future<void> onFeatureFinished(feature) async {
+    features.add(feature);
+    final allScenariosPassed = scenariosInActiveFeature.every((s) => s.passed);
+
+    if (allScenariosPassed) {
+      await slackMessenger.sendText(
+          ':white_check_mark: ${feature.name} (${scenariosInActiveFeature.length}/${scenariosInActiveFeature.length} passed)');
+    } else {
+      final passedScenarios = scenariosInActiveFeature.where((s) => s.passed);
+      await slackMessenger.sendText(
+          ':warning: ${feature.name} (${passedScenarios.length}/${scenariosInActiveFeature.length} passed)');
+    }
+
+    scenariosInActiveFeature.clear();
+  }
+
+  Future<void> onScenarioFinished(scenario) async {
+    scenarios.add(scenario);
+    scenariosInActiveFeature.add(scenario);
+    if (!scenario.passed) {
+      final payload = [
+        slackMessenger.buildTextSection(':x: ${scenario.name}'),
+        slackMessenger.buildTextSection('Failed at step: ${firstFailedStepInActiveScenario.name}'),
+      ];
+      await slackMessenger.notifySlack(payload).then((_) => firstFailedStepInActiveScenario = null);
+    }
+
+    if (scenarios.where((s) => !s.passed).length > MAXIMUM_TOLERATED_FAILURES) {
+      await slackMessenger.sendText(':x: :x: :x: :x: Aborting: too many failures :x: :x: :x: :x:');
+      exit(1);
+    }
+  }
+
+  Future<void> onStepFinished(step) async {
+    if (step.result.result != StepExecutionResult.pass && firstFailedStepInActiveScenario == null) {
+      firstFailedStepInActiveScenario = step;
+    }
+  }
+
+  Future<void> onTestRunStarted() async => slackMessenger.start('Starting tests for $startLabel');
+
+  Future<void> onTestRunFinished() async {
+    final successfulNames = scenarios.where((s) => s.passed).map((s) => '* ${s.name}');
+    final failedNames = scenarios.where((s) => !s.passed).map((s) => '* ${s.name}');
+
+    final payload = [
+      slackMessenger.buildTextSection('Testing Complete'),
+      slackMessenger.divider,
+      slackMessenger.buildTextSection(
+          ':white_check_mark: ${successfulNames.length} / ${scenarios.length} Successful Tests:'),
+      slackMessenger.buildTextSection(successfulNames.join('\n')),
+      slackMessenger.divider,
+      slackMessenger
+          .buildTextSection(':x: ${failedNames.length} / ${scenarios.length} Failed Tests:'),
+      slackMessenger.buildTextSection(failedNames.join('\n')),
+    ];
+
+    return slackMessenger.notifySlack(payload);
+  }
+}

--- a/lib/src/flutter/reporters/slack_reporter.dart
+++ b/lib/src/flutter/reporters/slack_reporter.dart
@@ -153,28 +153,36 @@ class SlackReporter extends Reporter {
     if (!scenario.passed) {
       final payload = [
         slackMessenger.buildTextSection(':x: ${scenario.name}'),
-        slackMessenger.buildTextSection('Failed at step: ${firstFailedStepInActiveScenario.name}'),
+        slackMessenger.buildTextSection(
+            'Failed at step: ${firstFailedStepInActiveScenario.name}'),
       ];
-      await slackMessenger.notifySlack(payload).then((_) => firstFailedStepInActiveScenario = null);
+      await slackMessenger
+          .notifySlack(payload)
+          .then((_) => firstFailedStepInActiveScenario = null);
     }
 
     if (scenarios.where((s) => !s.passed).length > MAXIMUM_TOLERATED_FAILURES) {
-      await slackMessenger.sendText(':x: :x: :x: :x: Aborting: too many failures :x: :x: :x: :x:');
+      await slackMessenger.sendText(
+          ':x: :x: :x: :x: Aborting: too many failures :x: :x: :x: :x:');
       exit(1);
     }
   }
 
   Future<void> onStepFinished(step) async {
-    if (step.result.result != StepExecutionResult.pass && firstFailedStepInActiveScenario == null) {
+    if (step.result.result != StepExecutionResult.pass &&
+        firstFailedStepInActiveScenario == null) {
       firstFailedStepInActiveScenario = step;
     }
   }
 
-  Future<void> onTestRunStarted() async => slackMessenger.start('Starting tests for $startLabel');
+  Future<void> onTestRunStarted() async =>
+      slackMessenger.start('Starting tests for $startLabel');
 
   Future<void> onTestRunFinished() async {
-    final successfulNames = scenarios.where((s) => s.passed).map((s) => '* ${s.name}');
-    final failedNames = scenarios.where((s) => !s.passed).map((s) => '* ${s.name}');
+    final successfulNames =
+        scenarios.where((s) => s.passed).map((s) => '* ${s.name}');
+    final failedNames =
+        scenarios.where((s) => !s.passed).map((s) => '* ${s.name}');
 
     final payload = [
       slackMessenger.buildTextSection('Testing Complete'),
@@ -183,8 +191,8 @@ class SlackReporter extends Reporter {
           ':white_check_mark: ${successfulNames.length} / ${scenarios.length} Successful Tests:'),
       slackMessenger.buildTextSection(successfulNames.join('\n')),
       slackMessenger.divider,
-      slackMessenger
-          .buildTextSection(':x: ${failedNames.length} / ${scenarios.length} Failed Tests:'),
+      slackMessenger.buildTextSection(
+          ':x: ${failedNames.length} / ${scenarios.length} Failed Tests:'),
       slackMessenger.buildTextSection(failedNames.join('\n')),
     ];
 


### PR DESCRIPTION
This is a rudimentary reporter that reports test results to a Slack channel as they are generated by the driver. Failed steps are reported to Slack with a screenshot. Successful features are reported to Slack with a green checkmark and the number of scenarios that passed within the feature.

Configurable options include terminating after a minimum number of failures and threading test run reports.