### PR TITLE
Add ability to consume `dart-define` args

### DIFF
--- a/lib/src/flutter/flutter_run_process_handler.dart
+++ b/lib/src/flutter/flutter_run_process_handler.dart
@@ -52,6 +52,7 @@ class FlutterRunProcessHandler extends ProcessHandler {
   String _workingDirectory;
   String _appTarget;
   String _buildFlavor;
+  List<String> _dartDefineArgs;
   String _deviceTargetId;
   Duration _driverConnectionDelay = const Duration(seconds: 2);
   String currentObservatoryUri;
@@ -84,6 +85,10 @@ class FlutterRunProcessHandler extends ProcessHandler {
     _deviceTargetId = deviceTargetId;
   }
 
+  void setDartDefineArgs(List<String> dartDefineArgs) {
+    _dartDefineArgs = dartDefineArgs;
+  }
+
   void setBuildRequired(bool build) {
     _buildApp = build;
   }
@@ -112,6 +117,12 @@ class FlutterRunProcessHandler extends ProcessHandler {
 
     if (_buildFlavor != null && _buildFlavor.isNotEmpty) {
       arguments.add('--flavor=$_buildFlavor');
+    }
+
+    if (_dartDefineArgs != null && _dartDefineArgs.isNotEmpty) {
+      _dartDefineArgs.forEach((element) {
+        arguments.add('--dart-define=$element');
+      });
     }
 
     if (_deviceTargetId != null && _deviceTargetId.isNotEmpty) {

--- a/lib/src/flutter/flutter_test_configuration.dart
+++ b/lib/src/flutter/flutter_test_configuration.dart
@@ -88,6 +88,10 @@ class FlutterTestConfiguration extends TestConfiguration {
   /// Defaults to empty
   String targetDeviceId = '';
 
+  /// `--dart-define` args to pass into the build parameters. Include the name and value
+  /// for each. For example, `--dart-define=MY_VAR="true"` becomes `['MY_VAR="true"']`
+  List<String> dartDefineArgs = [];
+
   /// Will keep the Flutter application running when done testing
   /// Defaults to false
   bool keepAppRunningAfterTests = false;

--- a/lib/src/flutter/hooks/app_runner_hook.dart
+++ b/lib/src/flutter/hooks/app_runner_hook.dart
@@ -77,7 +77,8 @@ class FlutterAppRunnerHook extends Hook {
         ..setKeepAppRunning(config.keepAppRunningAfterTests)
         ..setBuildFlavor(config.buildFlavor)
         ..setBuildMode(config.buildMode)
-        ..setDeviceTargetId(config.targetDeviceId);
+        ..setDeviceTargetId(config.targetDeviceId)
+        ..setDartDefineArgs(config.dartDefineArgs);
 
       stdout.writeln(
           "Starting Flutter app under test '${config.targetAppPath}', this might take a few moments");


### PR DESCRIPTION
Noticed there was no way to configure this; if there's any changes needed lmk