### PR TITLE
Fixed unnecessary assignment in runScenario

### DIFF
--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -137,8 +137,8 @@ class FeatureFileTestGeneratorVisitor extends FeatureFileVisitor {
     (TestDependencies dependencies) async {
       {{steps}}
     },
-    onBefore: {{onBefore}},
-    onAfter: {{onAfter}},
+    {{onBefore}}
+    {{onAfter}}
   );
   ''';
   static const String STEP_TEMPLATE = '''
@@ -150,10 +150,10 @@ class FeatureFileTestGeneratorVisitor extends FeatureFileVisitor {
   );
   ''';
   static const String ON_BEFORE_SCENARIO_RUN = '''
-  () async => onBeforeRunFeature('{{feature_name}}', {{feature_tags}},)
+  onBefore: () async => onBeforeRunFeature('{{feature_name}}', {{feature_tags}},),
   ''';
   static const String ON_AFTER_SCENARIO_RUN = '''
-  () async => onAfterRunFeature('{{feature_name}}',)
+  onAfter: () async => onAfterRunFeature('{{feature_name}}',),
   ''';
 
   final StringBuffer _buffer = StringBuffer();
@@ -223,12 +223,12 @@ class FeatureFileTestGeneratorVisitor extends FeatureFileVisitor {
     _currentScenarioCode = _replaceVariable(
       SCENARIO_TEMPLATE,
       'onBefore',
-      isFirst ? ON_BEFORE_SCENARIO_RUN : 'null',
+      isFirst ? ON_BEFORE_SCENARIO_RUN : '',
     );
     _currentScenarioCode = _replaceVariable(
       _currentScenarioCode!,
       'onAfter',
-      isLast ? ON_AFTER_SCENARIO_RUN : 'null',
+      isLast ? ON_AFTER_SCENARIO_RUN : '',
     );
     _currentScenarioCode = _replaceVariable(
       _currentScenarioCode!,


### PR DESCRIPTION
In the code generator, the runScenario function has 2 parameters, onBefore and onAfter. These are assigned with null if there is nothing to do. Because you do not have to do this, dart analyzer and VS code gives a hint that this does not have to be assigned.

Because this mixed with the real code, this removes this unnecessary assignment. 