### PR TITLE
Updated Readme to use the flutter test command

### DIFF
--- a/example_with_integration_test/README.md
+++ b/example_with_integration_test/README.md
@@ -3,5 +3,5 @@
 flutter pub run build_runner build --delete-conflicting-outputs
 
 # run the tests
-flutter drive --driver=test_driver/integration_test_driver.dart --target=integration_test/gherkin_suite_test.dart
+flutter test integration_test
 ```


### PR DESCRIPTION
The flutter team recommends using flutter test <test> command instead of flutter drive for running the integration test. Hence updating the readme file. The flutter drive command generates the following issue "flutter_integration" plugin not found similar to "https://github.com/flutter/flutter/issues/83929".