### PR TITLE
Allow disabling semantics in testWidgets

### DIFF
--- a/lib/src/flutter/configuration/flutter_test_configuration.dart
+++ b/lib/src/flutter/configuration/flutter_test_configuration.dart
@@ -20,6 +20,7 @@ import 'package:flutter_gherkin/src/flutter/steps/when_long_press_widget_step.da
 import 'package:flutter_gherkin/src/flutter/steps/when_pause_step.dart';
 import 'package:flutter_gherkin/src/flutter/steps/when_tap_widget_step.dart';
 import 'package:flutter_gherkin/src/flutter/steps/when_tap_the_back_button_step.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:gherkin/gherkin.dart';
 
 class FlutterTestConfiguration extends TestConfiguration {
@@ -49,7 +50,11 @@ class FlutterTestConfiguration extends TestConfiguration {
   /// Instead of using this variable, give the features in the `@GherkinTestSuite(features: <String>[])` option.
   @deprecated
   FeatureFileReader featureFileReader = const IoFeatureFileAccessor();
-
+  
+  /// Enable semantics in a test by creating a [SemanticsHandle].
+  /// See:  [testWidgets] and [WidgetController.ensureSemantics].
+  bool semanticsEnabled = true;
+  
   /// Provide a configuration object with default settings such as the reports and feature file location
   /// Additional setting on the configuration object can be set on the returned instance.
   static FlutterTestConfiguration DEFAULT(

--- a/lib/src/flutter/runners/gherkin_integration_test_runner.dart
+++ b/lib/src/flutter/runners/gherkin_integration_test_runner.dart
@@ -206,6 +206,9 @@ abstract class GherkinIntegrationTestRunner {
           }
         },
         timeout: scenarioExecutionTimeout,
+        semanticsEnabled: configuration is FlutterTestConfiguration
+            ? (configuration as FlutterTestConfiguration).semanticsEnabled
+            : true,
       );
     } else {
       _safeInvokeFuture(


### PR DESCRIPTION
Due to https://github.com/flutter/flutter/issues/97606 we currently have problems to execute our tests on web.

Therefore it would be very nice to have the option to disable the semantics handling when executing the tests.

Hope I used the right place to put in the configuration. As this is a flutter option only, I don't expect it to move to `gherkin` configuration. But it also can be used without flutter driver, so I think `flutter_test_configuration` is the right choice (was wondering anyways why not using `FlutterTestConfiguration` everywhere in the flutter specific package 😅 )