### PR TITLE
chore(docs): fix link to Gherkin Dart package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A fully featured Gherkin parser and test runner.  Works with Flutter and Dart 2.
 
 This implementation of the Gherkin tries to follow as closely as possible other implementations of Gherkin and specifically [Cucumber](https://docs.cucumber.io/cucumber/) in it's various forms.
 
-Available as a Dart package https://pub.dartlang.org/packages/flutter_gherkin
+Available as a Dart package https://pub.dev/packages/gherkin
 
 ``` dart
   # Comment


### PR DESCRIPTION
Dart package was actually pointing to this very same flutter_gherkin package