### PR TITLE
--keep-app-running is no more avaliable

### DIFF
--- a/lib/src/flutter/flutter_run_process_handler.dart
+++ b/lib/src/flutter/flutter_run_process_handler.dart
@@ -134,10 +134,6 @@ class FlutterRunProcessHandler extends ProcessHandler {
       arguments.add('--verbose');
     }
 
-    if (_keepAppRunning) {
-      arguments.add('--keep-app-running');
-    }
-
     if (_logFlutterProcessOutput) {
       stdout.writeln(
         'Invoking from working directory `${_workingDirectory ?? './'}` command: `flutter ${arguments.join(' ')}`',
@@ -173,7 +169,11 @@ class FlutterRunProcessHandler extends ProcessHandler {
     var exitCode = -1;
     _ensureRunningProcess();
     if (_runningProcess != null) {
-      _runningProcess!.stdin.write('q');
+      if (_keepAppRunning) {
+        _runningProcess!.stdin.write('d');
+      } else {
+        _runningProcess!.stdin.write('q');
+      }
       _openSubscriptions.forEach((s) => s.cancel());
       _openSubscriptions.clear();
       exitCode = await _runningProcess!.exitCode;


### PR DESCRIPTION
hi guys, --keep-app-running is no more available in flutter stable SDK (3.0.4),
My solution will be to send detach command 'd' instead of quit command 'q' when we terminate flutter process.
Let me know if you want to discuss more.