### PR TITLE
make stepMaxRetries and retryDelay configurable

### DIFF
--- a/lib/src/flutter/adapters/widget_tester_app_driver_adapter.dart
+++ b/lib/src/flutter/adapters/widget_tester_app_driver_adapter.dart
@@ -99,18 +99,22 @@ class WidgetTesterAppDriverAdapter
   Future<List<int>> screenshot({String? screenshotName}) async {
     final name =
         screenshotName ?? 'screenshot_${DateTime.now().millisecondsSinceEpoch}';
-    if (kIsWeb || Platform.isAndroid) {
-      // try {
-      //   // TODO: See https://github.com/flutter/flutter/issues/92381
-      //   // we need to call `revertFlutterImage` once it has been implemented
-      //   await binding.convertFlutterSurfaceToImage();
-      //   await binding.pump();
-      //   // ignore: no_leading_underscores_for_local_identifiers
-      // } catch (_, __) {}
-
-      return await takeScreenshotUsingRenderElement();
-    } else {
+    if (kIsWeb) {
       return await binding.takeScreenshot(name);
+    } else {
+      if (Platform.isAndroid) {
+        // try {
+        //   // TODO: See https://github.com/flutter/flutter/issues/92381
+        //   // we need to call `revertFlutterImage` once it has been implemented
+        //   await binding.convertFlutterSurfaceToImage();
+        //   await binding.pump();
+        //   // ignore: no_leading_underscores_for_local_identifiers
+        // } catch (_, __) {}
+
+        return await takeScreenshotUsingRenderElement();
+      } else {
+        return await binding.takeScreenshot(name);
+      }
     }
   }
 

--- a/lib/src/flutter/configuration/flutter_test_configuration.dart
+++ b/lib/src/flutter/configuration/flutter_test_configuration.dart
@@ -96,6 +96,8 @@ class FlutterTestConfiguration extends TestConfiguration {
     super.hooks,
     super.reporters = const [],
     super.createWorld,
+    super.stepMaxRetries = 0,
+    super.retryDelay = const Duration(seconds: 2),
     this.semanticsEnabled = true,
     this.waitImplicitlyAfterAction = false,
     Iterable<CustomParameter<dynamic>>? customStepParameterDefinitions,

--- a/lib/src/flutter/hooks/attach_screenshot_on_failed_step_hook.dart
+++ b/lib/src/flutter/hooks/attach_screenshot_on_failed_step_hook.dart
@@ -14,7 +14,7 @@ class AttachScreenshotOnFailedStepHook extends Hook {
         stepResult.result == StepExecutionResult.error ||
         stepResult.result == StepExecutionResult.timeout) {
       try {
-        final screenshotData = await _takeScreenshot(world);
+        final screenshotData = await _takeScreenshot(world, step);
         world.attach(screenshotData, 'image/png', step);
       } catch (e, st) {
         world.attach('Failed to take screenshot\n$e\n$st', 'text/plain', step);
@@ -22,8 +22,10 @@ class AttachScreenshotOnFailedStepHook extends Hook {
     }
   }
 
-  Future<String> _takeScreenshot(World world) async {
-    final bytes = await (world as FlutterWorld).appDriver.screenshot();
+  Future<String> _takeScreenshot(World world, String step) async {
+    final bytes = await (world as FlutterWorld)
+        .appDriver
+        .screenshot(screenshotName: step);
 
     return base64Encode(bytes);
   }

--- a/lib/src/flutter/runners/gherkin_integration_test_runner.dart
+++ b/lib/src/flutter/runners/gherkin_integration_test_runner.dart
@@ -80,6 +80,8 @@ abstract class GherkinIntegrationTestRunner {
   Future<void> run() async {
     _binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+    _binding.testTextInput.register();
+
     _binding.framePolicy = framePolicy ?? _binding.framePolicy;
 
     tearDownAll(


### PR DESCRIPTION
Context:
dart_Gherkin 3.1.0 has configuration: stepMaxRetries and retryDelay, but they are not introduced by FlutterTestConfiguration, we can't configure them from our configuration.
what this PR do:
add these two configurations into construction function, so we could configure them.