### PR TITLE
Change scroll code to make it working also for AnimatedList

### DIFF
--- a/lib/src/flutter/adapters/widget_tester_app_driver_adapter.dart
+++ b/lib/src/flutter/adapters/widget_tester_app_driver_adapter.dart
@@ -251,7 +251,7 @@ class WidgetTesterAppDriverAdapter
       find.byType(Scrollable),
       matchRoot: true,
     );
-    final state = nativeDriver.state(scrollableFinder) as ScrollableState;
+    final state = nativeDriver.firstState(scrollableFinder) as ScrollableState;
     final position = state.position;
     position.jumpTo(dy ?? dx ?? 0);
 


### PR DESCRIPTION
AnimatedList is not subclassing from ScrollView, and the seen behaviour was that nativeDriver.state was trying to ensure that a single state is available which is not true for AnimatedList. Regression test was performed on ListView.