### PR TITLE
fix(web): wrong pass on integration tests

### DIFF
--- a/example_with_integration_test/integration_test/gherkin_suite_test.dart
+++ b/example_with_integration_test/integration_test/gherkin_suite_test.dart
@@ -8,6 +8,7 @@ part 'gherkin_suite_test.g.dart';
 
 @GherkinTestSuite(
   useAbsolutePaths: false,
+  executionOrder: ExecutionOrder.sequential
 )
 void main() {
   executeTestSuite(

--- a/example_with_integration_test/integration_test/gherkin_suite_test.g.dart
+++ b/example_with_integration_test/integration_test/gherkin_suite_test.g.dart
@@ -38,7 +38,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
         runScenario(
           name: 'User can create single todo item',
           description: null,
-          path: '.\\integration_test\\features\\create.feature',
+          path: './integration_test/features/create.feature',
           tags: <String>['@tag'],
           steps: [
             (
@@ -92,7 +92,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
           ],
           onBefore: () async => onBeforeRunFeature(
             name: 'Creating todos',
-            path: '.\\integration_test\\features\\create.feature',
+            path: './integration_test/features/create.feature',
             description: null,
             tags: <String>['@tag'],
           ),
@@ -101,8 +101,8 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
         runScenario(
           name: 'User can create multiple new todo items',
           description: null,
-          path: '.\\integration_test\\features\\create.feature',
-          tags: <String>['@tag', '@debug2'],
+          path: './integration_test/features/create.feature',
+          tags: <String>['@tag'],
           steps: [
             (
               TestDependencies dependencies,
@@ -242,7 +242,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
           ],
           onAfter: () async => onAfterRunFeature(
             name: 'Creating todos',
-            path: '.\\integration_test\\features\\create.feature',
+            path: './integration_test/features/create.feature',
             description: null,
             tags: <String>['@tag'],
           ),
@@ -253,80 +253,13 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
 
   void testFeature1() {
     runFeature(
-      name: 'Checking data:',
-      tags: <String>['@tag'],
-      run: () {
-        runScenario(
-          name: 'User can have data',
-          description: null,
-          path: '.\\integration_test\\features\\check.feature',
-          tags: <String>['@tag', '@tag1'],
-          steps: [
-            (
-              TestDependencies dependencies,
-              bool skip,
-            ) async {
-              return await runStep(
-                name: 'Given I have item with data',
-                multiLineStrings: <String>[
-                  """{
-  "glossary": {
-    "title": "example glossary",
-    "GlossDiv": {
-      "title": "S",
-      "GlossList": {
-        "GlossEntry": {
-          "ID": "SGML",
-          "SortAs": "SGML",
-          "GlossTerm": "Standard Generalized Markup Language",
-          "Acronym": "SGML",
-          "Abbrev": "ISO 8879:1986",
-          "GlossDef": {
-            "para": "A meta-markup language, used to create markup languages such as DocBook.",
-            "GlossSeeAlso": [
-              "GML",
-              "XML"
-            ]
-          },
-          "GlossSee": "markup"
-        }
-      }
-    }
-  }
-}"""
-                ],
-                table: null,
-                dependencies: dependencies,
-                skip: skip,
-              );
-            },
-          ],
-          onBefore: () async => onBeforeRunFeature(
-            name: 'Checking data',
-            path: '.\\integration_test\\features\\check.feature',
-            description: null,
-            tags: <String>['@tag'],
-          ),
-          onAfter: () async => onAfterRunFeature(
-            name: 'Checking data',
-            path: '.\\integration_test\\features\\check.feature',
-            description: null,
-            tags: <String>['@tag'],
-          ),
-        );
-      },
-    );
-  }
-
-  void testFeature2() {
-    runFeature(
       name: 'Swiping:',
       tags: <String>['@tag'],
       run: () {
         runScenario(
           name: 'User can swipe cards left and right',
           description: null,
-          path: '.\\integration_test\\features\\swiping.feature',
+          path: './integration_test/features/swiping.feature',
           tags: <String>['@tag'],
           steps: [
             (
@@ -382,13 +315,80 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
           ],
           onBefore: () async => onBeforeRunFeature(
             name: 'Swiping',
-            path: '.\\integration_test\\features\\swiping.feature',
+            path: './integration_test/features/swiping.feature',
             description: null,
             tags: <String>['@tag'],
           ),
           onAfter: () async => onAfterRunFeature(
             name: 'Swiping',
-            path: '.\\integration_test\\features\\swiping.feature',
+            path: './integration_test/features/swiping.feature',
+            description: null,
+            tags: <String>['@tag'],
+          ),
+        );
+      },
+    );
+  }
+
+  void testFeature2() {
+    runFeature(
+      name: 'Checking data:',
+      tags: <String>['@tag'],
+      run: () {
+        runScenario(
+          name: 'User can have data',
+          description: null,
+          path: './integration_test/features/check.feature',
+          tags: <String>['@tag', '@tag1'],
+          steps: [
+            (
+              TestDependencies dependencies,
+              bool skip,
+            ) async {
+              return await runStep(
+                name: 'Given I have item with data',
+                multiLineStrings: <String>[
+                  """{
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": "SGML",
+          "SortAs": "SGML",
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": [
+              "GML",
+              "XML"
+            ]
+          },
+          "GlossSee": "markup"
+        }
+      }
+    }
+  }
+}"""
+                ],
+                table: null,
+                dependencies: dependencies,
+                skip: skip,
+              );
+            },
+          ],
+          onBefore: () async => onBeforeRunFeature(
+            name: 'Checking data',
+            path: './integration_test/features/check.feature',
+            description: null,
+            tags: <String>['@tag'],
+          ),
+          onAfter: () async => onAfterRunFeature(
+            name: 'Checking data',
+            path: './integration_test/features/check.feature',
             description: null,
             tags: <String>['@tag'],
           ),
@@ -399,60 +399,13 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
 
   void testFeature3() {
     runFeature(
-      name: 'Parsing:',
-      tags: <String>['@debug'],
-      run: () {
-        runScenario(
-          name: 'Parsing a',
-          description: null,
-          path: '.\\integration_test\\features\\parsing.feature',
-          tags: <String>['@debug'],
-          steps: [
-            (
-              TestDependencies dependencies,
-              bool skip,
-            ) async {
-              return await runStep(
-                name: 'Given the text "^[A-Z]{3}\\\\d{5}\\\$"',
-                multiLineStrings: <String>[],
-                table: null,
-                dependencies: dependencies,
-                skip: skip,
-              );
-            },
-          ],
-          onBefore: () async => onBeforeRunFeature(
-            name: 'Parsing',
-            path: '.\\integration_test\\features\\parsing.feature',
-            description: """Complex description:
-- Line "one".
-- Line two, more text
-- Line three""",
-            tags: <String>['@debug'],
-          ),
-          onAfter: () async => onAfterRunFeature(
-            name: 'Parsing',
-            path: '.\\integration_test\\features\\parsing.feature',
-            description: """Complex description:
-- Line "one".
-- Line two, more text
-- Line three""",
-            tags: <String>['@debug'],
-          ),
-        );
-      },
-    );
-  }
-
-  void testFeature4() {
-    runFeature(
       name: 'Expect failures:',
       tags: <String>[],
       run: () {
         runScenario(
           name: 'Exception should be added to json report',
           description: null,
-          path: '.\\integration_test\\features\\failure.feature',
+          path: './integration_test/features/failure.feature',
           tags: <String>['@failure-expected'],
           steps: [
             (
@@ -471,7 +424,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
           ],
           onBefore: () async => onBeforeRunFeature(
             name: 'Expect failures',
-            path: '.\\integration_test\\features\\failure.feature',
+            path: './integration_test/features/failure.feature',
             description:
                 """Ensure that when a test fails the exception or test failure is reported""",
             tags: <String>[],
@@ -481,7 +434,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
         runScenario(
           name: 'Failed expect() should be added to json report',
           description: "Description for this scenario!",
-          path: '.\\integration_test\\features\\failure.feature',
+          path: './integration_test/features/failure.feature',
           tags: <String>['@failure-expected'],
           steps: [
             (
@@ -523,10 +476,57 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
           ],
           onAfter: () async => onAfterRunFeature(
             name: 'Expect failures',
-            path: '.\\integration_test\\features\\failure.feature',
+            path: './integration_test/features/failure.feature',
             description:
                 """Ensure that when a test fails the exception or test failure is reported""",
             tags: <String>[],
+          ),
+        );
+      },
+    );
+  }
+
+  void testFeature4() {
+    runFeature(
+      name: 'Parsing:',
+      tags: <String>['@debug'],
+      run: () {
+        runScenario(
+          name: 'Parsing a',
+          description: null,
+          path: './integration_test/features/parsing.feature',
+          tags: <String>['@debug'],
+          steps: [
+            (
+              TestDependencies dependencies,
+              bool skip,
+            ) async {
+              return await runStep(
+                name: 'Given the text "^[A-Z]{3}\\\\d{5}\\\$"',
+                multiLineStrings: <String>[],
+                table: null,
+                dependencies: dependencies,
+                skip: skip,
+              );
+            },
+          ],
+          onBefore: () async => onBeforeRunFeature(
+            name: 'Parsing',
+            path: './integration_test/features/parsing.feature',
+            description: """Complex description:
+- Line "one".
+- Line two, more text
+- Line three""",
+            tags: <String>['@debug'],
+          ),
+          onAfter: () async => onAfterRunFeature(
+            name: 'Parsing',
+            path: './integration_test/features/parsing.feature',
+            description: """Complex description:
+- Line "one".
+- Line two, more text
+- Line three""",
+            tags: <String>['@debug'],
           ),
         );
       },
@@ -537,7 +537,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
 void executeTestSuite({
   required FlutterTestConfiguration configuration,
   required StartAppFn appMainFunction,
-  Timeout scenarioExecutionTimeout = const Timeout(Duration(minutes: 10)),
+  Timeout scenarioExecutionTimeout = const Timeout(const Duration(minutes: 10)),
   AppLifecyclePumpHandlerFn? appLifecyclePumpHandler,
   LiveTestWidgetsFlutterBindingFramePolicy? framePolicy,
 }) {

--- a/example_with_integration_test/ios/Flutter/Debug.xcconfig
+++ b/example_with_integration_test/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example_with_integration_test/ios/Flutter/Release.xcconfig
+++ b/example_with_integration_test/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example_with_integration_test/ios/Podfile
+++ b/example_with_integration_test/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '11.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example_with_integration_test/pubspec.lock
+++ b/example_with_integration_test/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.3.0"
   args:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   dart_style:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -324,21 +324,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -359,7 +359,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -511,7 +511,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -539,28 +539,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   timing:
     dependency: transitive
     description:
@@ -574,7 +574,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   uuid:
     dependency: "direct main"
     description:
@@ -595,7 +595,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.2"
+    version: "9.0.0"
   watcher:
     dependency: transitive
     description:

--- a/lib/src/flutter/runners/gherkin_integration_test_runner.dart
+++ b/lib/src/flutter/runners/gherkin_integration_test_runner.dart
@@ -261,6 +261,7 @@ abstract class GherkinIntegrationTestRunner {
             );
 
             await cleanUpScenarioRun(dependencies);
+            expect(failed, false);
           }
         },
         timeout: scenarioExecutionTimeout,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.3.0"
   args:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -77,14 +77,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -98,7 +91,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: "direct main"
     description:
@@ -119,7 +112,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
@@ -147,7 +140,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   file:
     dependency: transitive
     description:
@@ -235,21 +228,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: "direct dev"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   package_config:
     dependency: transitive
     description:
@@ -263,7 +256,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pedantic:
     dependency: "direct dev"
     description:
@@ -324,7 +317,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -345,35 +338,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   uuid:
     dependency: transitive
     description:
@@ -394,7 +387,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.2.2"
+    version: "9.0.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
Plz inform, if have to split in multiple smaller PRs.

See: #275 

I think the main problem is, that the failures are caught inside the `gherkin_integration_test_runner` and aren't reported to the integration_test package. So it passes. Why it only happens on web, I don't really know.

But for all of the platforms. A scenario should never pass, if one step fails. So I would recommend to simply apply it everywhere, as this should be the final "ultimate" test, even if it does not show the exact step, where it fails. At least the CI never passes a scenario, which has not passed all of its steps, whatever is happening.
Of course one should determine the source of the failure.