### PR TITLE
Make it possible to run the tests with flutter test instead of flutter drive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ targets:
       # Allows the code generator to target files outside of the lib folder
       - integration_test/**.dart
 ```
-3. Add the following file (and folder) `\test_driver\integration_test_driver.dart`.  This file is the entry point to run your tests.  See `https://flutter.dev/docs/testing/integration-tests` for more information.
+3. Add the following file (and folder) `\test_driver\integration_test_driver.dart`.  This file is the entry point to run your tests.
+If you want ot use the flutter test command approach, you will not need this file (and be unused when it is created).
+See `https://flutter.dev/docs/testing/integration-tests` for more information.
 ```dart
 import 'package:integration_test/integration_test_driver.dart' as integration_test_driver;
 
@@ -83,25 +85,25 @@ import 'package:example_with_integration_test/main.dart' as app;
 
 part 'gherkin_suite_test.g.dart';
 
-@GherkinTestSuite()
-void main() {
-  executeTestSuite(
-    FlutterTestConfiguration.DEFAULT([])
-      ..reporters = [
-        StdoutReporter(MessageLevel.error)
-          ..setWriteLineFn(print)
-          ..setWriteFn(print),
-        ProgressReporter()
-          ..setWriteLineFn(print)
-          ..setWriteFn(print),
-        TestRunSummaryReporter()
-          ..setWriteLineFn(print)
-          ..setWriteFn(print),
-        JsonReporter(
-          writeReport: (_, __) => Future<void>.value(),
-        ),
-      ],
-    (World world) => app.main(),
+@GherkinTestSuite(
+    featurePaths: <String>['integration_test/features/**.feature'],
+    executionOrder: ExecutionOrder.sequential)
+Future<void> main() async {
+  if (Config().restoreDatabase) {
+    await MakeSnapshotCommand().action(null);
+  }
+  var configuration = FlutterTestConfiguration(
+    reporters: [
+      TestRunSummaryReporter(),
+      JsonReporter(
+        writeReport: (_, __) => Future<void>.value(),
+      ),
+    ],
+  );
+
+  await executeTestSuite(
+      configuration: configuration,
+      appMainFunction: (World world) async => app.main(),
   );
 }
 ```
@@ -114,6 +116,14 @@ flutter pub run build_runner build
 ```
 flutter drive --driver=test_driver/integration_test_driver.dart --target=integration_test/gherkin_suite_test.dart
 ```
+
+If you do not want to use the flutter drive command, but the flutter test command you need to change some aspects.
+It is REQUIRED that in `integration_test\gherkin_suite_test.dart` the executeTestSuite is awaited.
+And then you can run your test command:
+```
+flutter test integration_test/gherkin_suite_test.dart
+```
+
 10. You can debug the tests by adding a breakpoint to line 12 in `integration_test\gherkin_suite_test.dart` and adding the below to your `.vscode\launch.json` file:
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ part 'gherkin_suite_test.g.dart';
     featurePaths: <String>['integration_test/features/**.feature'],
     executionOrder: ExecutionOrder.sequential)
 Future<void> main() async {
-  if (Config().restoreDatabase) {
-    await MakeSnapshotCommand().action(null);
-  }
+  
   var configuration = FlutterTestConfiguration(
     reporters: [
       TestRunSummaryReporter(),

--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -51,7 +51,7 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
   {{feature_functions}}
 }
 
-Future executeTestSuite({
+Future<void> executeTestSuite({
   required FlutterTestConfiguration configuration,
   required StartAppFn appMainFunction,
   Timeout scenarioExecutionTimeout = const Timeout(const Duration(minutes: 10)),

--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -51,14 +51,14 @@ class _CustomGherkinIntegrationTestRunner extends GherkinIntegrationTestRunner {
   {{feature_functions}}
 }
 
-void executeTestSuite({
+Future executeTestSuite({
   required FlutterTestConfiguration configuration,
   required StartAppFn appMainFunction,
   Timeout scenarioExecutionTimeout = const Timeout(const Duration(minutes: 10)),
   AppLifecyclePumpHandlerFn? appLifecyclePumpHandler,
   LiveTestWidgetsFlutterBindingFramePolicy? framePolicy,
-}) {
-  _CustomGherkinIntegrationTestRunner(
+}) async {
+  return _CustomGherkinIntegrationTestRunner(
     configuration: configuration,
     appMainFunction: appMainFunction,
     appLifecyclePumpHandler: appLifecyclePumpHandler,

--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -57,8 +57,8 @@ Future<void> executeTestSuite({
   Timeout scenarioExecutionTimeout = const Timeout(const Duration(minutes: 10)),
   AppLifecyclePumpHandlerFn? appLifecyclePumpHandler,
   LiveTestWidgetsFlutterBindingFramePolicy? framePolicy,
-}) async {
-  return _CustomGherkinIntegrationTestRunner(
+}) =>
+    _CustomGherkinIntegrationTestRunner(
     configuration: configuration,
     appMainFunction: appMainFunction,
     appLifecyclePumpHandler: appLifecyclePumpHandler,


### PR DESCRIPTION
For some reasons the possibility to use flutter test is more beneficial than to use flutter drive.

These changes make it possible to start the tests with flutter test instead of flutter drive.
The only required change to be able to use flutter test is to await the executeTestSuite method. This can also be done and STILL use flutter drive.

ISSUE #275 