### PR TITLE
Fix code generation error after e8c874f0c07d7f575f74501f31f71140d7edff80

### DIFF
--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -65,7 +65,7 @@ Future<void> executeTestSuite({
     scenarioExecutionTimeout: scenarioExecutionTimeout,
     framePolicy: framePolicy,
   ).run();
-}
+
 ''';
   final _reporter = NoOpReporter();
   final _languageService = LanguageService();


### PR DESCRIPTION
e8c874f0c07d7f575f74501f31f71140d7edff80 from title change function from async {} to => notation, but lower bracket wasn't removed. Because of this new version of build_runner is throwing error like this:
```
line 206, column 1 of .: Expected a method, getter, setter or operator declaration.
    ╷
206 │ }
    │ ^
    ╵
```