### PR TITLE
fix: Can't run automation test with Flutter 3.10.x

### DIFF
--- a/lib/src/flutter/flutter_run_process_handler.dart
+++ b/lib/src/flutter/flutter_run_process_handler.dart
@@ -13,7 +13,7 @@ class FlutterRunProcessHandler extends ProcessHandler {
   // `An Observatory debugger and profiler on AOSP on IA Emulator is available at: http://127.0.0.1:51322/BI_fyYaeoCE=/`
   // `Observatory URL on device: http://127.0.0.1:37849/t2xp9hvaxNs=/`
   static final RegExp _observatoryDebuggerUriRegex = RegExp(
-    r'observatory .*[:] (http[s]?:.*\/).*',
+    r'.*[:] (http[s]?:.*\/).*',
     caseSensitive: false,
     multiLine: false,
   );


### PR DESCRIPTION
Because flutter 3.10 change text, text doesn't contain "observatory" any more. We should change regex to be more general.