### PR TITLE
Remove unnecessary_await_in_return warning from gherkin g.dart files

### DIFF
--- a/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
+++ b/lib/src/flutter/code_generation/generators/gherkin_suite_test_generator.dart
@@ -173,7 +173,7 @@ class FeatureFileTestGeneratorVisitor extends FeatureFileVisitor {
   ''';
   static const String stepTemplate = '''
 (TestDependencies dependencies, bool skip,) async {
-  return await runStep(
+  return runStep(
     name: '{{step_name}}',
     multiLineStrings: {{step_multi_line_strings}},
     table: {{step_table}},


### PR DESCRIPTION
Hello @jonsamwell ,
In our project we have enabled more static analysis rules than the default ones and one of them is https://dart.dev/tools/linter-rules/unnecessary_await_in_return .
Whenever the g.dart files are being regenerated, we see thousands of warnings in the gherkin g.dart files and that is impacting our daily development activity.

Please approve this small change which was already tested without seen regressions.
Thank you