### PR TITLE
Commit for new release for Fix - Can't run automation test with Flutter 3.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.1.0] - 28/05/2023
+* Fix - Can't run automation test with Flutter 3.10.x
+
 ## [2.0.0] - 25/05/2021
  * null-safety migration, thanks to @tshedor
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_gherkin
 description: A Gherkin / Cucumber parser and test runner for Dart and Flutter
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/jonsamwell/flutter_gherkin
 
 environment:


### PR DESCRIPTION
Commit for new release for Fix - Can't run automation test with Flutter 3.10.x